### PR TITLE
Speed up computation time

### DIFF
--- a/lib/core-sampling.R
+++ b/lib/core-sampling.R
@@ -346,7 +346,7 @@ sampleTwoFromRings <- function(max.dist = 2000, delta.d = 250,
 ##'   spatial structure of these distances must follow the structure of
 ##'   \code{field}.
 ##' @param .parallel logical; whether to parallelize the correlation
-##'   computations for the individual ring bin combinations. Defaults to
+##'   computations of the individual ring bin combinations. Defaults to
 ##'   \code{TRUE}.
 ##' @param mc.cores integer; the number of cores to use for the parallel
 ##'   computation, i.e. at most how many child processes will be run


### PR DESCRIPTION
This PR introduces the following changes to the `sampleNFromRings()` function to speed up computation time:

* the `for` loops to cycle through the number of ring bin combinations and through the number of Monte Carlo samples have been changed to `lapply` approaches, which brings some reduction of computation time;
* the computation of the target correlations for each ring bin combination can now be parallelized using the `base R` functionality from the `parallel` package. This brings a major improvement in computation time. Note here, however, that the random sampling of the grid cells for each ring bin combination cannot be parallelized, since this step involves drawing random numbers with the random number generator, for which parallelization is, apparently, not possible. Therefore, this computation is done separately.