### PR TITLE
Replace deprecated ecustools package

### DIFF
--- a/analysis/correlation-2-cores-opt-distances.R
+++ b/analysis/correlation-2-cores-opt-distances.R
@@ -97,7 +97,7 @@ p <- p +
           legend.title = element_text(size = 18),
           text = element_text(size = 15))
 
-p <- ecustools::ggpolar(pole = "S", max.lat = -60, min.lat = -90,
+p <- grfxtools::ggpolar(pole = "S", max.lat = -60, min.lat = -90,
                         n.lat.labels = 3,
                         longitude.spacing = 45,
                         land.fill.colour = "transparent",

--- a/analysis/correlation-increase-riskanalysis.R
+++ b/analysis/correlation-increase-riskanalysis.R
@@ -142,8 +142,8 @@ mtext("Correlation", side = 2, line = 4.5, cex = par()$cex.lab, las = 0)
 mtext(label1, side = 3, line = -1.5, cex = par()$cex.lab,
       adj = 0.02, padj = -0.35)
 
-ecustools::Polyplot(N, y1 = edml$local, y2 = edml$optim, col = col1)
-ecustools::Polyplot(N, y1 = vost$local, y2 = vost$optim, col = col2)
+grfxtools::Polyplot(N, y1 = edml$local, y2 = edml$optim, col = col1)
+grfxtools::Polyplot(N, y1 = vost$local, y2 = vost$optim, col = col2)
 
 lines(N, edml$local, col = col1, lty = 2, lwd = 1.5)
 lines(N, edml$optim, col = col1, lty = 1, lwd = 2.5)

--- a/analysis/estimate-model-params.R
+++ b/analysis/estimate-model-params.R
@@ -140,5 +140,5 @@ x <- dml.t2m.pw$distances$mean
 independent.fit <- sqrt(1 - xi.dml.t2m.pw) * exp(-x/tau.dml.t2m.pw)
 parameter.fit   <- sqrt(1 - xi.dml) * exp(-x/tau.dml.t2m)
 
-ecustools::rmsd(dml.t2m.pw$correlation$mean, independent.fit)
-ecustools::rmsd(dml.t2m.pw$correlation$mean, parameter.fit)
+stattools::rmsd(dml.t2m.pw$correlation$mean, independent.fit)
+stattools::rmsd(dml.t2m.pw$correlation$mean, parameter.fit)

--- a/analysis/local-t2m-oxy-correlation.R
+++ b/analysis/local-t2m-oxy-correlation.R
@@ -62,7 +62,7 @@ p <- p +
           legend.title = element_text(size = 18),
           text = element_text(size = 15))
 
-p1 <- ecustools::ggpolar(pole = "S", max.lat = -60, min.lat = -90,
+p1 <- grfxtools::ggpolar(pole = "S", max.lat = -60, min.lat = -90,
                         n.lat.labels = 3,
                         longitude.spacing = 45,
                         land.fill.colour = "transparent",
@@ -88,7 +88,7 @@ p <- p +
           legend.title = element_text(size = 18),
           text = element_text(size = 15))
 
-p2 <- ecustools::ggpolar(pole = "S", max.lat = -60, min.lat = -90,
+p2 <- grfxtools::ggpolar(pole = "S", max.lat = -60, min.lat = -90,
                         n.lat.labels = 3,
                         longitude.spacing = 45,
                         land.fill.colour = "transparent",

--- a/analysis/plot-concept-figure.R
+++ b/analysis/plot-concept-figure.R
@@ -21,7 +21,7 @@ focus  <- data.frame(lat = lat0, lon = lon0)
 df.lst <- list()
 for (i in 1 : length(radii)) {
 
-  tmp <- ecustools::CircleCoordinates(lat0, lon0, radii[i])
+  tmp <- geostools::CircleCoordinates(lat0, lon0, radii[i])
   tmp$id <- i
   df.lst[[i]] <- tmp
   
@@ -63,7 +63,7 @@ p <- p +
   geom_point(data = focus, aes(x = lon, y = lat),
              col = "black", size = 2.5, pch = 3, stroke = 1)
 
-p <- ecustools::ggpolar(pole = "S", max.lat = -60, min.lat = -90,
+p <- grfxtools::ggpolar(pole = "S", max.lat = -60, min.lat = -90,
                         n.lat.labels = 3,
                         longitude.spacing = 45,
                         land.fill.colour = "transparent",

--- a/analysis/temperature-decorrelation.R
+++ b/analysis/temperature-decorrelation.R
@@ -47,7 +47,7 @@ p <- p +
           legend.title = element_text(size = 18),
           text = element_text(size = 15))
 
-p <- ecustools::ggpolar(pole = "S", max.lat = -60, min.lat = -90,
+p <- grfxtools::ggpolar(pole = "S", max.lat = -60, min.lat = -90,
                         n.lat.labels = 3,
                         longitude.spacing = 45,
                         land.fill.colour = "transparent",

--- a/analysis/test-ring-monte-carlo.R
+++ b/analysis/test-ring-monte-carlo.R
@@ -44,7 +44,7 @@ for (i in 1 : length(nmc)) {
 }
 
 mismatch <- sapply(doubles.mc, function(x, exact) {
-  ecustools::rmsd(x$correlation$mean, exact$correlation$mean)},
+  stattools::rmsd(x$correlation$mean, exact$correlation$mean)},
   exact = doubles.exact)
 
 # ------------------------------------------------------------------------------

--- a/dependencies.R
+++ b/dependencies.R
@@ -12,6 +12,8 @@ install.packages("magrittr")
 install.packages("RColorBrewer")
 
 # install.packages("remotes")
-remotes::install_github("EarthSystemDiagnostics/ecustools")
+remotes::install_github("EarthSystemDiagnostics/geostools")
+remotes::install_github("EarthSystemDiagnostics/grfxtools")
 remotes::install_github("EarthSystemDiagnostics/pfields")
+remotes::install_github("EarthSystemDiagnostics/stattools")
 

--- a/init.R
+++ b/init.R
@@ -9,8 +9,8 @@
 # ------------------------------------------------------------------------------
 # Load required packages
 
-required.packages <- c("abind", "arrangements", "ecustools", "egg", "magrittr",
-                       "pfields", "RColorBrewer")
+required.packages <- c("abind", "arrangements", "egg", "geostools", "grfxtools",
+                       "magrittr", "pfields", "RColorBrewer", "stattools")
 
 for (pkg in required.packages) {
 

--- a/init.R
+++ b/init.R
@@ -16,7 +16,7 @@ for (pkg in required.packages) {
 
   if (!require(pkg, character.only = TRUE, quietly = TRUE)) {
     stop(sprintf("Package \"%s\" needed for \"optimalcores\". ", pkg),
-         "Please install it.", call. = FALSE)
+         "Please install it using \"dependencies.R\".", call. = FALSE)
   }
 }
 

--- a/lib/plotting-helpers.R
+++ b/lib/plotting-helpers.R
@@ -162,7 +162,7 @@ plotPicking <- function(data, N, cor.min = 0, cor.max = 0.5,
           legend.title = element_text(size = 18),
           text = element_text(size = 18))
 
-  p <- ecustools::ggpolar(pole = "S", max.lat = -60, min.lat = -90,
+  p <- grfxtools::ggpolar(pole = "S", max.lat = -60, min.lat = -90,
                           n.lat.labels = 3,
                           min.lon = min.lon, max.lon = max.lon, rotate = TRUE,
                           longitude.spacing = 30,
@@ -239,7 +239,7 @@ plotCorrelationContours <- function(correlation, distances, color.palette,
 
 ##' Plot ring bin sampling occurrence
 ##'
-##' Produce a plot of the number of cores each ring around a a target site has
+##' Produce a plot of the number of cores each ring around a target site has
 ##' been sampled in the optimal cases.
 ##'
 ##' @param data the output of \code{processCores} called with data from
@@ -292,7 +292,7 @@ plotRingOccurrences <- function(data,
   for (i in 1 : nrank) {
     ni <- length(ring.occurrences[i, ])
 
-    ecustools::Polyplot(x = xlim, y1 = rep(i - 0.5, 2), y2 = rep(i + 0.5, 2),
+    grfxtools::Polyplot(x = xlim, y1 = rep(i - 0.5, 2), y2 = rep(i + 0.5, 2),
                         col = shading[i], alpha = alpha)
     points(ring.occurrences[i, ], rep(i, ni), pch = pch, cex = cex)
   }

--- a/lib/select-data.R
+++ b/lib/select-data.R
@@ -164,13 +164,13 @@ setTarget <- function(field, site = "edml", lat0 = NULL, lon0 = NULL) {
     # is pField
     res$dist <-
       pfields::GetDistanceField(field,
-                                  lat = lat0, lon = lon0,
-                                  get.nearest = TRUE)
+                                lat = lat0, lon = lon0,
+                                get.nearest = TRUE)
     
   } else {
     # is pTs
     res$dist <-
-      ecustools::GetDistance(lat0 = lat0, lon0 = lon0,
+      geostools::GetDistance(lat0 = lat0, lon0 = lon0,
                              lat = pfields::GetLat(field[, i.sel]),
                              lon = pfields::GetLon(field[, i.sel]),
                              get.nearest = TRUE)
@@ -232,8 +232,8 @@ setTargetRegion <- function(field,
 
     mid.lat <- (min.lat + max.lat) / 2
     mid.lon <- (min.lon + max.lon) / 2
-    x <- ecustools::GetDistance(mid.lat, mid.lon, mid.lat, max(lons))
-    y <- ecustools::GetDistance(mid.lat, mid.lon, min(lats), mid.lon)
+    x <- geostools::GetDistance(mid.lat, mid.lon, mid.lat, max(lons))
+    y <- geostools::GetDistance(mid.lat, mid.lon, min(lats), mid.lon)
 
     midpoint.border.distances <- c(x = x, y = y)
     cat(sprintf("Midpoint-border distances:\nx = %4.0f, y = %4.0f.\n",


### PR DESCRIPTION
Package [ecustools](https://github.com/EarthSystemDiagnostics/ecustools) is deprecated and replaced by slimmer, more theme-oriented packages; among others these are [geostools](https://github.com/EarthSystemDiagnostics/geostools), [grfxtools](https://github.com/EarthSystemDiagnostics/grfxtools), and [stattools](https://github.com/EarthSystemDiagnostics/stattools).

This PR introduces the required changes for replacing ecustools with these new packages.